### PR TITLE
Fixes for deprecated code

### DIFF
--- a/HTML/Template/IT.php
+++ b/HTML/Template/IT.php
@@ -1088,9 +1088,9 @@ class HTML_Template_IT
         $content = fread($fh, $fsize);
         fclose($fh);
 
-        return preg_replace(
-            "#<!-- INCLUDE (.*) -->#ime",
-            "\$this->getFile('\\1')",
+        return preg_replace_callback(
+            "#<!-- INCLUDE (.*) -->#im",
+            function ($m) { return $this->getFile($m[1]); },
             $content
         );
     } // end func getFile

--- a/HTML/Template/IT.php
+++ b/HTML/Template/IT.php
@@ -407,7 +407,7 @@ class HTML_Template_IT
      * @see      setRoot()
      * @access   public
      */
-    function HTML_Template_IT($root = '', $options = null)
+     function __construct($root = '', $options = null)
     {
         if (!is_null($options)) {
             $this->setOptions($options);

--- a/HTML/Template/ITX.php
+++ b/HTML/Template/ITX.php
@@ -136,7 +136,7 @@ class HTML_Template_ITX extends HTML_Template_IT
      * @access public
      * @see    HTML_Template_IT()
      */
-    function HTML_Template_ITX($root = '')
+     function __construct($root = '')
     {
 
         $this->checkblocknameRegExp = '@' . $this->blocknameRegExp . '@';
@@ -144,7 +144,7 @@ class HTML_Template_ITX extends HTML_Template_IT
         $this->functionRegExp = '@' . $this->functionPrefix . '(' .
                                 $this->functionnameRegExp . ')\s*\(@sm';
 
-        $this->HTML_Template_IT($root);
+        parent::__construct($root);
     } // end func constructor
 
     /**

--- a/HTML/Template/IT_Error.php
+++ b/HTML/Template/IT_Error.php
@@ -56,7 +56,7 @@ class IT_Error extends PEAR_Error
      * @param string $file file where the error occured
      * @param string $line linenumber where the error occured
      */
-    function IT_Error($msg, $file = __FILE__, $line = __LINE__)
+    function __construct($msg, $file = __FILE__, $line = __LINE__)
     {
         $this->PEAR_Error(sprintf("%s [%s on line %d].", $msg, $file, $line)); 
     } // end func IT_Error

--- a/examples/sample_itx_addblockfile.php
+++ b/examples/sample_itx_addblockfile.php
@@ -6,6 +6,10 @@
  * @version CVS: $Id$
  */
 
+// Show all errors and warnings
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
 require_once 'HTML/Template/ITX.php';
 
 $data = array (array ('packagename'=>'mypackage',


### PR DESCRIPTION
Fix for bug #20956: Use of deprecated '/e' flag to preg_replace().  This functionality is no longer supported at all, so this library was broken in newer versions of PHP.
Also updated constructors to newer '__construct()' style as this was giving deprecation warnings as well, although not currently breaking anything.