### PR TITLE
Support for PHP 7.2

### DIFF
--- a/HTML/Template/ITX.php
+++ b/HTML/Template/ITX.php
@@ -311,7 +311,7 @@ class HTML_Template_ITX extends HTML_Template_IT
         } elseif (count($parents) > 1) {
 
             reset($parents);
-            while (list($k, $parent) = each($parents)) {
+            foreach ($parents as $k => $parent) {
                 $msg .= "$parent, ";
             }
             $msg = substr($parent, -2);
@@ -397,7 +397,7 @@ class HTML_Template_ITX extends HTML_Template_IT
             if (is_array($variables = $this->blockvariables[$block])) {
                 // search the value in the list of blockvariables
                 reset($variables);
-                while (list($k, $variable) = each($variables)) {
+                foreach ($variables as $k => $variable) {
                     if ($k == $placeholder) {
                         $found = $block;
                         break;
@@ -409,7 +409,7 @@ class HTML_Template_ITX extends HTML_Template_IT
             // search all blocks and return the name of the first block that
             // contains the placeholder
             reset($this->blockvariables);
-            while (list($blockname, $variables) = each($this->blockvariables)) {
+            foreach ($this->blockvariables as $blockname => $variables) {
                 if (is_array($variables) && isset($variables[$placeholder])) {
                     $found = $blockname;
                     break;
@@ -430,7 +430,7 @@ class HTML_Template_ITX extends HTML_Template_IT
     function performCallback()
     {
         reset($this->functions);
-        while (list($func_id, $function) = each($this->functions)) {
+        foreach ($this->functions as $func_id => $function) {
             if (isset($this->callback[$function['name']])) {
                 if ($this->callback[$function['name']]['expandParameters']) {
                     $callFunction = 'call_user_func_array';
@@ -782,7 +782,7 @@ class HTML_Template_ITX extends HTML_Template_IT
         }
 
         reset($this->blockvariables[$block]);
-        while (list($varname, $val) = each($this->blockvariables[$block])) {
+        foreach ($this->blockvariables[$block] as $varname => $val) {
             if (isset($variables[$varname])) {
                 unset($this->blockvariables[$block][$varname]);
             }
@@ -840,10 +840,10 @@ class HTML_Template_ITX extends HTML_Template_IT
     {
         $parents = array();
         reset($this->blocklist);
-        while (list($blockname, $content) = each($this->blocklist)) {
+        foreach ($this->blocklist as $blockname => $content) {
             reset($this->blockvariables[$blockname]);
 
-            while (list($varname, $val) = each($this->blockvariables[$blockname])) {
+            foreach ($this->blockvariables[$blockname] as $varname => $val) {
                 if ($variable == $varname) {
                     $parents[] = $blockname;
                 }

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,6 @@
         "pear/pear-core-minimal": "^1.10.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^3"
+        "phpunit/phpunit": "^5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,6 @@
         "pear/pear-core-minimal": "^1.10.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5"
+        "phpunit/phpunit": "^4"
     }
 }

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -3,8 +3,6 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
     define('PHPUnit_MAIN_METHOD', 'HTML_Template_IT_AllTests::main');
 }
 
-require_once 'PHPUnit/TextUI/TestRunner.php';
-require_once 'PHPUnit/Framework/TestSuite.php';
 
 
 require_once 'ITTest.php';

--- a/tests/ITTest.php
+++ b/tests/ITTest.php
@@ -1,6 +1,5 @@
 <?php
 require_once 'HTML/Template/IT.php';
-require_once 'PHPUnit/Framework/TestCase.php';
 
 class ITTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/ITTest.php
+++ b/tests/ITTest.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'HTML/Template/IT.php';
+require_once 'PHPUnit/Framework/TestCase.php';
 
 class ITTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/ITXTest.php
+++ b/tests/ITXTest.php
@@ -1,6 +1,5 @@
 <?php
 require_once 'HTML/Template/ITX.php';
-require_once 'PHPUnit/Framework/TestCase.php';
 
 require_once 'ITTest.php';
 

--- a/tests/ITXTest.php
+++ b/tests/ITXTest.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'HTML/Template/ITX.php';
+require_once 'PHPUnit/Framework/TestCase.php';
 
 require_once 'ITTest.php';
 


### PR DESCRIPTION
PHP 7.1 was supported by this PR ( https://github.com/pear/HTML_Template_IT/pull/2 ). But CI was failing on PHP 7.2 because of using deprecated [each](http://php.net/manual/en/function.each.php) function on PHP 7.2.0.

So I fixed the problem by removing each function.

### References
* [PHP: Deprecated features in PHP 7\.2\.x \- Manual](http://php.net/manual/en/migration72.deprecated.php)