### PR TITLE
fix: PHP 7.4 Array and string offset access syntax with curly braces …

### DIFF
--- a/HTML/Template/IT.php
+++ b/HTML/Template/IT.php
@@ -1065,7 +1065,7 @@ class HTML_Template_IT
      */
     function getFile($filename)
     {
-        if ($filename{0} == '/' && substr($this->fileRoot, -1) == '/') {
+        if ($filename[0] == '/' && substr($this->fileRoot, -1) == '/') {
             $filename = substr($filename, 1);
         }
 

--- a/HTML/Template/ITX.php
+++ b/HTML/Template/ITX.php
@@ -536,7 +536,7 @@ class HTML_Template_ITX extends HTML_Template_IT
     $expandCallbackParameters = false) {
         if ($tplfunction == '' || $callbackfunction == '') {
             return new IT_Error("No template function "."('$tplfunction')".
-                                " and/or no callback function ('$callback') given.",
+                                " and/or no callback function ('$callbackfunction') given.",
                                 __FILE__, __LINE__);
         }
         $this->callback[$tplfunction] = array(


### PR DESCRIPTION
…is deprecated