### PR TITLE
fix: Array and string offset access syntax with curly braces is no longer supported

### DIFF
--- a/HTML/Template/ITX.php
+++ b/HTML/Template/ITX.php
@@ -696,7 +696,7 @@ class HTML_Template_ITX extends HTML_Template_IT
             while ($head != '' && $args2 = $this->getValue($head, ',')) {
                 $arg2 = trim($args2);
 
-                $args[] = ('"' == $arg2{0} || "'" == $arg2{0}) ?
+                $args[] = ('"' == $arg2[0] || "'" == $arg2[0]) ?
                                     substr($arg2, 1, -1) : $arg2;
 
                 if ($arg2 == $head) {


### PR DESCRIPTION
This PR is similar to #10: it fixes the syntax for array access for recent versions of PHP in class `HTML_Template_ITX`.