### PR TITLE
Remove PHP < 5.6 and add last versions of PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: php
 sudo: false
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+# Disable xdebug for PHP >= 7.3
+# https://stackoverflow.com/questions/65172031/vendor-bin-phpunit-exited-with-2
+before_script:
+  - phpenv config-rm xdebug.ini
 script:
   - pear list
   - pear channel-update pear.php.net

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "type": "library",
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.6",
         "pear/pear-core-minimal": "^1.10.1"
     },
     "require-dev": {


### PR DESCRIPTION
This PR removes old versions of PHP before 5.6 because they are no longer available on travis (except on old systems -see [here](https://docs.travis-ci.com/user/languages/php/#php-versions)) and are no longer supported on PEAR.

It also adds the last versions of PHP 7.