### PR TITLE
Port the test suite to PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: php
 sudo: false
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
+  - 8.1
 script:
   - pear list
   - pear channel-update pear.php.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 7.3
   - 7.4
   - 8.0
-  - 8.1
+  - 8.1.0
 script:
   - pear list
   - pear channel-update pear.php.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ php:
   - 7.4
   - 8.0
   - 8.1.0
+  - 8.2.0
+  - 8.3.0
 # Disable xdebug for PHP >= 7.3
 # https://stackoverflow.com/questions/65172031/vendor-bin-phpunit-exited-with-2
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,6 @@
         "pear/pear-core-minimal": "^1.10.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^9.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,10 @@
     },
     "type": "library",
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.0",
         "pear/pear-core-minimal": "^1.10.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4"
+        "phpunit/phpunit": "^6"
     }
 }

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -11,15 +11,17 @@ require_once 'ITXTest.php';
 
 class HTML_Template_IT_AllTests
 {
+    private static $runner;
+
     public static function main()
     {
-
-        PHPUnit_TextUI_TestRunner::run(self::suite());
+        $runner = new PHPUnit\TextUI\TestRunner;
+        $runner->run(self::suite());
     }
 
     public static function suite()
     {
-        $suite = new PHPUnit_Framework_TestSuite('HTML_Template_IT tests');
+        $suite = new PHPUnit\Framework\TestSuite('HTML_Template_IT tests');
 
         $suite->addTestSuite('ITTest');
         $suite->addTestSuite('ITXTest');

--- a/tests/ITTest.php
+++ b/tests/ITTest.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'HTML/Template/IT.php';
 
-class ITTest extends PHPUnit_Framework_TestCase
+class ITTest extends PHPUnit\Framework\TestCase
 {
    /**
     * An HTML_Template_IT object
@@ -9,12 +9,12 @@ class ITTest extends PHPUnit_Framework_TestCase
     */
     var $tpl;
 
-    function setUp()
+    protected function setUp(): void
     {
         $this->tpl = new HTML_Template_IT(dirname(__FILE__) . '/templates');
     }
 
-    function tearDown()
+    protected function tearDown(): void
     {
         unset($this->tpl);
     }

--- a/tests/ITXTest.php
+++ b/tests/ITXTest.php
@@ -23,7 +23,7 @@ class Callbacks
 
 class ITXTest extends ITTest
 {
-    function setUp()
+    function setUp(): void
     {
         $this->tpl = new HTML_Template_ITX(dirname(__FILE__) . '/templates');
     }


### PR DESCRIPTION
This PR follows #11 and #12. Here we port the test suite to PHP 8. This requires `PHP Unit >= 9.3` which requires to drop support for PHP 5.6.