### PR TITLE
Declare property blockparents

### DIFF
--- a/HTML/Template/IT.php
+++ b/HTML/Template/IT.php
@@ -272,6 +272,13 @@ class HTML_Template_IT
     var $blockinner = array();
 
     /**
+     * Array of parent block of a block.
+     * @var      array
+     * @access   private
+     */
+    var $blockparents = array();
+
+    /**
      * List of blocks to preverse even if they are "empty".
      *
      * This is something special. Sometimes you have blocks that


### PR DESCRIPTION
This PR declares property `blockparents` in class `HTML_Template_IT`.

The property was used but not declared (this was discovered while working on #16). So called dynamic properties are deprecated since PHP 8.2. I suggest to merge this after #18.