### PR TITLE
Add `check_placeholder_exists` option and `setGlobalOptions` method

### DIFF
--- a/HTML/Template/IT.php
+++ b/HTML/Template/IT.php
@@ -389,8 +389,11 @@ class HTML_Template_IT
     var $_options = array(
         'preserve_data' => false,
         'use_preg'      => true,
-        'preserve_input'=> true
+        'preserve_input'=> true,
+        'check_placeholder_exists' => true,
     );
+
+    public static $globalOptions = [];
 
     /**
      * Builds some complex regular expressions and optionally sets the
@@ -408,6 +411,9 @@ class HTML_Template_IT
      */
      function __construct($root = '', $options = null)
     {
+        if (!empty(self::$globalOptions)) {
+            $this->setOptions(self::$globalOptions);
+        }
         if (!is_null($options)) {
             $this->setOptions($options);
         }
@@ -479,6 +485,16 @@ class HTML_Template_IT
         }
 
         return IT_OK;
+    }
+
+    /**
+     * Define global options used for all new instances.
+     * options defined using constructor parameter will overwrite
+     * globalOptions
+     */
+    public static function setGlobalOptions($options)
+    {
+        self::$globalOptions = $options;
     }
 
     /**
@@ -766,7 +782,7 @@ class HTML_Template_IT
                 $this->setVariable($key, $value);
             }
         } else {
-            if ($this->checkPlaceholderExists($this->currentBlock, $variable)) {
+            if (!$this->_options['check_placeholder_exists'] ||  $this->checkPlaceholderExists($this->currentBlock, $variable)) {
                 $this->variableCache[$variable] = $value;
             }
         }


### PR DESCRIPTION
Hi,

I'm trying to get rid of our 10 years old fork migrating legacy code under php8.4 to switch on new servers... Everything works fine if :

* I skip the `checkPlaceholderExists` test...
* I set `preserve_input` option to `false`

In this PR, I added a `check_placeholder_exists` option to skip the check, and a static `setGlobalOptions` method to define options globaly for all future instances. 

Hope you can accept this PR, it will be a real cost saving for me .

